### PR TITLE
fix: upgrade quality model to qwen3.5:35b

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,11 +14,11 @@ TIMEZONE=America/New_York
 # ---- Ollama (Local Inference — True MVP) ----
 # Ollama runs on the WSL2 host, accessible from Docker via host networking.
 # No API key required. Models must be pulled first:
-#   ollama pull qwen3.5:27b        (~18GB, quality model)
-#   ollama pull qwen3.5:35b-a3b    (~21GB, speed model)
+#   ollama pull qwen3.5:35b        (~23GB, quality model)
+#   ollama pull qwen3.5:35b-a3b    (~18GB MoE, speed model)
 OLLAMA_BASE_URL=http://host.docker.internal:11434
 OLLAMA_SPEED_MODEL=qwen3.5:35b-a3b
-OLLAMA_QUALITY_MODEL=qwen3.5:27b
+OLLAMA_QUALITY_MODEL=qwen3.5:35b
 
 # ---- Full MVP: API Providers (Optional) ----
 # Uncomment and configure when adding cloud API fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.2.1] — 2026-03-01
+
+### Fixed
+- Corrected quality model from `qwen3.5:27b` to `qwen3.5:35b` (dense 23GB) — confirmed working on RTX 4090 24GB
+- Updated VRAM and throughput figures: speed model `qwen3.5:35b-a3b` is ~18GB MoE at ~40-60 tok/s; quality model `qwen3.5:35b` is ~23GB at ~24-32 tok/s
+- Updated all references across `.env.example`, `docker-compose.yml`, `setup.sh`, `README.md`, and agent prompt front-matter (`council-chair.md`, `prd-writer.md`)
+
+---
+
 ## [0.2.0] — 2026-03-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ Two models are used and **cannot run simultaneously** on a 24GB GPU:
 | Role | Model | VRAM | Used for |
 |------|-------|------|----------|
 | Speed | `qwen3.5:35b-a3b` | ~18GB | Interview turns, council reviewers |
-| Quality | `qwen3.5:27b` | ~18GB | PRD synthesis, council chair |
+| Quality | `qwen3.5:35b` | ~23GB | PRD synthesis, council chair |
 
 Pull both before running:
 ```bash
 ollama pull qwen3.5:35b-a3b
-ollama pull qwen3.5:27b
+ollama pull qwen3.5:35b
 ```
 
 The setup script handles this automatically.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       # Ollama endpoint — accessible from container via Docker host networking
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
       - OLLAMA_SPEED_MODEL=${OLLAMA_SPEED_MODEL:-qwen3.5:35b-a3b}
-      - OLLAMA_QUALITY_MODEL=${OLLAMA_QUALITY_MODEL:-qwen3.5:27b}
+      - OLLAMA_QUALITY_MODEL=${OLLAMA_QUALITY_MODEL:-qwen3.5:35b}
 
       # Full MVP API providers (uncomment when needed)
       # - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}

--- a/prompts/prd-council/core/council-chair.md
+++ b/prompts/prd-council/core/council-chair.md
@@ -1,7 +1,7 @@
 ---
 agent: council-chair
 phase: 4
-model: quality (qwen3.5:27b)
+model: quality (qwen3.5:35b)
 skills:
   - skills/council/council-synthesis.md
 ---

--- a/prompts/prd-development/prd-writer.md
+++ b/prompts/prd-development/prd-writer.md
@@ -1,7 +1,7 @@
 ---
 agent: prd-writer
 phase: 3
-model: quality (qwen3.5:27b)
+model: quality (qwen3.5:35b)
 skills:
   - skills/prd/requirements-engineering.md
   - skills/prd/gov-prd-requirements.md  # conditional: include when compliance frameworks identified in interview

--- a/setup.sh
+++ b/setup.sh
@@ -107,11 +107,11 @@ echo ""
 # ---- Pull models ----
 
 SPEED_MODEL="qwen3.5:35b-a3b"
-QUALITY_MODEL="qwen3.5:27b"
+QUALITY_MODEL="qwen3.5:35b"
 
 echo -e "${BLUE}Checking required models...${NC}"
-echo -e "  Speed model:   ${SPEED_MODEL} (~21GB)"
-echo -e "  Quality model: ${QUALITY_MODEL} (~18GB)"
+echo -e "  Speed model:   ${SPEED_MODEL} (~18GB MoE)"
+echo -e "  Quality model: ${QUALITY_MODEL} (~23GB)"
 echo ""
 
 EXISTING_MODELS=$(ollama list 2>/dev/null | awk '{print $1}' || echo "")


### PR DESCRIPTION
## Summary

- Replaces `qwen3.5:27b` with `qwen3.5:35b` as the quality model after confirming the 23GB dense model runs without OOM on RTX 4090 (24GB VRAM)
- Corrects VRAM and throughput figures throughout the project
- Updates CHANGELOG with v0.2.1 entry

## Model strategy (updated)

| Role | Model | VRAM | Throughput |
|------|-------|------|------------|
| Speed | `qwen3.5:35b-a3b` | ~18GB MoE | ~40-60 tok/s |
| Quality | `qwen3.5:35b` | ~23GB | ~24-32 tok/s |

## Files changed

- `.env.example` — `OLLAMA_QUALITY_MODEL` default
- `docker-compose.yml` — fallback env var default
- `setup.sh` — `QUALITY_MODEL` var + size label
- `README.md` — model table + pull instructions
- `prompts/prd-council/core/council-chair.md` — front-matter model tag
- `prompts/prd-development/prd-writer.md` — front-matter model tag
- `CHANGELOG.md` — v0.2.1 entry

## Test plan

- [x] `qwen3.5:35b` confirmed loading on RTX 4090 24GB without OOM
- [x] 7.8s load time, 24-32 tok/s inference speed verified

🤖 Generated with [Claude Code](https://claude.ai/claude-code)